### PR TITLE
Updated etathermmodbus.py to work with HA release 2025.1

### DIFF
--- a/custom_components/etetherm_modbus/etathermmodbus.py
+++ b/custom_components/etetherm_modbus/etathermmodbus.py
@@ -8,7 +8,6 @@ from math import floor
 
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
-from pymodbus.transaction import ModbusRtuFramer
 from .const import CONF_MODBUS_RETR, CONF_MODBUS_RETR_WAIT, CONF_MODBUS_TIMEOUT
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Removed import of ModbusRtuFramer which was removed from library and is missing in latest HA release.